### PR TITLE
Ensure we handle Polygon mode correctly

### DIFF
--- a/src/Includes/TerrainGenerator.hpp
+++ b/src/Includes/TerrainGenerator.hpp
@@ -67,6 +67,7 @@ class TerrainGenerator : public OGLApplication {
   // polygon representation
   GLenum polygonModes[2] = {GL_FILL, GL_LINE};
   int polygonMode = 0;
+  bool polygonModePressed = false;
 
   // input handling
   void processInput(GLFWwindow*);

--- a/src/TerrainGenerator.cpp
+++ b/src/TerrainGenerator.cpp
@@ -178,8 +178,13 @@ void TerrainGenerator::processInput(GLFWwindow* window) {
     exit();
   }
 
-  if (glfwGetKey(window, GLFW_KEY_P) == GLFW_PRESS) {
+  if (polygonModePressed && glfwGetKey(window, GLFW_KEY_P) == GLFW_RELEASE) {
+    polygonModePressed = false;
     polygonMode = (polygonMode + 1) % 2;
     glPolygonMode(GL_FRONT_AND_BACK, polygonModes[polygonMode]);
+  }
+  else
+  {
+    polygonModePressed = glfwGetKey(window, GLFW_KEY_P) == GLFW_PRESS;
   }
 }


### PR DESCRIPTION
 When we press down on the P key we need to save that so that when someone releases the key later we correctly switch the mode.